### PR TITLE
Add support for macOS (and technically, linux as well)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Growtopia Discord Rich Presence by GrowStocks.
 
 
 # Instructions
-- Download the .exe from the "Releases" tab
-- Open the .exe file (the presence will only show if Growtopia and Discord are open at the same time) 
+- Download the correct file for your OS from the "Releases" tab
+- Open the downloaded file (the presence will only show if Growtopia and Discord are open at the same time) 
 - If the Rich Presence doesn't show on Discord, try completely closing then re-opening Discord
 
 # Instructions (if you're a skeptic)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Growtopia Discord Rich Presence by GrowStocks.
 
 
 # Instructions
-- Download the correct file for your OS from the "Releases" tab
+- Download the correct file for your operating system from the "Releases" tab
 - Open the downloaded file (the presence will only show if Growtopia and Discord are open at the same time) 
 - If the Rich Presence doesn't show on Discord, try completely closing then re-opening Discord
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ data = null;
 			data = await Growtopia.generateRPCData();
 			if(Growtopia.clientIsOpen) client.setActivity(data).catch(e=>e);
 		}catch(e){
+			console.log(e);
 			process.exit(0);
 		}
 	}

--- a/modules/Application.js
+++ b/modules/Application.js
@@ -1,10 +1,14 @@
 const path = require('path');
 const fetch = require('node-fetch');
+var os = require('os');
 
 class Application {
     constructor() {
         this.clientID = "841694148758208542";
-        this.version = "v1.1.1";
+        this.version = "v1.3.1";
+        this.device = {
+            isMacOS: os.platform() === 'darwin'
+        };
     }
 
     checkForUpdates(){

--- a/modules/DiscordHelper.js
+++ b/modules/DiscordHelper.js
@@ -1,5 +1,7 @@
+const exec = require('child_process').exec;
 const findProcess = require('find-process');
 const EventEmitter = require('events');
+const Application = require('../modules/Application.js');
 
 class DiscordHelper extends EventEmitter {
 	constructor(){
@@ -8,12 +10,25 @@ class DiscordHelper extends EventEmitter {
 	}
 
 	async isOpen(){
+		if(Application.device.isMacOS) return await this.isOpenMacOS();
+		else return await this.isOpenWindows();
+	}
+
+	async isOpenWindows(){
+		return new Promise((resolve, reject) => {
+			exec('tasklist', (err, stdout, stderr) => {
+				if(!stdout) resolve(false);
+				resolve(stdout.includes("Discord.exe"));
+			});
+		});
+	}
+
+	async isOpenMacOs(){
 		return new Promise((resolve, reject) => {
 			let isFound = findProcess('name', 'Discord').then(list => {
 				for (let ver of ['', ' PTB', ' Canary']) {
 					for (let process of list) {
 						if (process.name === 'Discord' + ver) {
-							// console.log('[DEBUG] - Found ' + 'Discord' + ver);
 							return true;
 						}
 					}

--- a/modules/DiscordHelper.js
+++ b/modules/DiscordHelper.js
@@ -1,4 +1,4 @@
-const exec = require('child_process').exec;
+const findProcess = require('find-process');
 const EventEmitter = require('events');
 
 class DiscordHelper extends EventEmitter {
@@ -9,10 +9,18 @@ class DiscordHelper extends EventEmitter {
 
 	async isOpen(){
 		return new Promise((resolve, reject) => {
-			exec('tasklist', (err, stdout, stderr) => {
-				if(!stdout) resolve(false);
-				resolve(stdout.includes("Discord.exe"));
-			});
+			let isFound = findProcess('name', 'Discord').then(list => {
+				for (let ver of ['', ' PTB', ' Canary']) {
+					for (let process of list) {
+						if (process.name === 'Discord' + ver) {
+							// console.log('[DEBUG] - Found ' + 'Discord' + ver);
+							return true;
+						}
+					}
+				}
+				return false;
+			})
+			resolve(isFound);
 		});
 	}
 

--- a/modules/GrowtopiaHelper.js
+++ b/modules/GrowtopiaHelper.js
@@ -76,7 +76,7 @@ class GrowtopiaHelper extends EventEmitter {
 			        largeImageKey: "growtopia",
 			        largeImageText: "Growtopia",
 			        smallImageKey: "growstocks",
-			        smallImageText: "By GrowStocks",
+			        smallImageText: "RPC By GrowStocks",
 			        startTimestamp: this.startedPlaying
 				});
 			}catch(e){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,52 @@
 {
   "name": "growtopia-discord-presence",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
     "discord-rpc": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/discord-rpc/-/discord-rpc-3.2.0.tgz",
@@ -13,10 +56,43 @@
         "ws": "^7.3.1"
       }
     },
+    "find-process": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.4.tgz",
+      "integrity": "sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "debug": "^4.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
     },
     "ws": {
       "version": "7.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "growtopia-discord-presence",
-  "version": "1.1.1",
+  "version": "1.3.1",
   "description": "Growtopia Discord Rich Presence by GrowStocks",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,9 @@
   "license": "GPL-3.0",
   "dependencies": {
     "discord-rpc": "^3.2.0",
-    "node-fetch": "^2.6.1"
+    "find-process": "^1.4.4",
+    "node-fetch": "^2.6.1",
+    "os": "^0.1.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Has been moderately tested. Is able to detect if discord and growtopia are open, but has not been tested to see if it fully works for rendering the presence. Also may be good to check that the changes don't break functionality on windows.

- [x] Test macOS functionality
- [x] Test windows functionality